### PR TITLE
non-optional data has been made optional.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,15 +14,15 @@ interface Props<DataType> {
   data: DataType[]
   renderNode: React.ElementType<RenderNodeProps<DataType>>
   initialExpanded: boolean
-  getCollapsedNodeHeight: (args: NodeAction<DataType>) => number
-  idKey: string
-  childrenKey: string
-  onNodePress: (
+  getCollapsedNodeHeight?: (args: NodeAction<DataType>) => number
+  idKey?: string
+  childrenKey?: string
+  onNodePress?: (
     args: NodeAction<DataType>
   ) => void | boolean | Promise<boolean> | Promise<void>
-  onNodeLongPress: (args: NodeAction<DataType>) => number
-  isNodeExpanded: (args: DataType) => boolean,
-  shouldDisableTouchOnLeaf: (args: NodeAction<DataType>) => boolean
+  onNodeLongPress?: (args: NodeAction<DataType>) => number
+  isNodeExpanded?: (args: DataType) => boolean,
+  shouldDisableTouchOnLeaf?: (args: NodeAction<DataType>) => boolean
 }
 
 export default class TreeView<DataType> extends React.Component<


### PR DESCRIPTION
**Problem**
* I have to add the optional data to the TreeView.

**Sample Error Output**
* No overload matches this call.
  Overload 1 of 2, '(props: Readonly<Props<unknown>>): TreeView<unknown>', gave the following error.
    Type '{ data: any[]; renderNode: ({ node, level, isExpanded, hasChildrenNodes }: PropsWithChildren<RenderNodeProps<unknown>>) => Element; childrenKey: string; initialExpanded: true; idKey: string; }' is missing the following properties from type 'Readonly<Props<unknown>>': getCollapsedNodeHeight, onNodePress, onNodeLongPress, isNodeExpanded, shouldDisableTouchOnLeaf
  Overload 2 of 2, '(props: Props<unknown>, context?: any): TreeView<unknown>', gave the following error.
    Type '{ data: any[]; renderNode: ({ node, level, isExpanded, hasChildrenNodes }: PropsWithChildren<RenderNodeProps<unknown>>) => Element; childrenKey: string; initialExpanded: true; idKey: string; }' is missing the following properties from type 'Readonly<Props<unknown>>': getCollapsedNodeHeight, onNodePress, onNodeLongPress, isNodeExpanded, shouldDisableTouchOnLeafts(2769)

**Solution**
* Safe Navigation Operator was used for data that should be optional.
